### PR TITLE
Improved building of assembly full path name

### DIFF
--- a/VDMHelperCLR.Common/VdmHelperFactory.cs
+++ b/VDMHelperCLR.Common/VdmHelperFactory.cs
@@ -11,8 +11,8 @@ namespace VDMHelperCLR.Common
 
         private static string GetPlatformDllName()
         {
-            var dir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\";
-            return dir + (!Environment.Is64BitProcess ? DllName32 : DllName64);
+            var dir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            return Path.Combine(dir, (!Environment.Is64BitProcess ? DllName32 : DllName64));
         }
 
         public static IVdmHelper CreateInstance()


### PR DESCRIPTION
Probably not necessary but this is more portable. I made this change when I was having problems getting the dll to load.
